### PR TITLE
fix(selenium): add_product_button [skip ci]

### DIFF
--- a/lib/apress/selenium_eti/spec/company_site/eti/product_creation_spec.rb
+++ b/lib/apress/selenium_eti/spec/company_site/eti/product_creation_spec.rb
@@ -40,7 +40,7 @@ describe 'ЕТИ' do
         @cs_eti_page.set_name(@name)
         @cs_eti_page.wait_saving
         @cs_eti_page.set_rubric(CONFIG['eti']['rubric'])
-        @cs_eti_page.wait_until { @cs_eti_page.first_product_status_element.attribute('title') == 'Опубликованные' }
+        @cs_eti_page.wait_until { @cs_eti_page.first_product_status_element.attribute('title') == 'Опубликованные на портале' }
         @cs_eti_page.refresh
         @cs_eti_page.search_product(@name)
       end

--- a/lib/pages/company_site/eti_page.rb
+++ b/lib/pages/company_site/eti_page.rb
@@ -20,7 +20,7 @@ module CompanySite
     span(:price_cell, xpath: "//*[contains(text(), 'Указать розничную цену')]")
     span(:wholesale_price_cell, css: '.js-eti-wholesaleprice .bp-price-free')
     span(:exist_cell, xpath: "//*[contains(text(), 'Указать наличие')]")
-    button(:add_product, css: '.new.js-add-product')
+    button(:add_product, css: '.js-add-product')
     text_area(:edit_text_area, css: '.edit-text')
 
     text_area(:price_text_area, css: '.js-text-price')


### PR DESCRIPTION
После https://jira.railsc.ru/browse/GOODS-1717, https://jira.railsc.ru/browse/GOODS-1762:
-изменился стиль кнопки для создания нового товара
-если товар с рубрикой, то его статус =  Опубликованные на портале