### PR TITLE
fix(selenium): fix eti after releases goods-june, goods-jule

### DIFF
--- a/lib/apress/selenium_eti/spec/company_site/eti/product_groups_spec.rb
+++ b/lib/apress/selenium_eti/spec/company_site/eti/product_groups_spec.rb
@@ -13,8 +13,10 @@ describe 'ЕТИ' do
   describe 'Добавление групп' do
     context 'когда привязываем группу к товару' do
       before(:all) do
-        @product = {name: Faker::Number.number(digits: 5).to_s}
+        @product = {name: Faker::Number.leading_zero_number(digits: 5).to_s}
         @cs_eti_page.create_and_set_product_fields(@product)
+        @cs_eti_page.navigate_to_groups_element.click
+        sleep 2
         @cs_eti_page.set_group(CONFIG['product_creation']['group'])
         @cs_eti_page.wait_saving
         @cs_eti_page.refresh

--- a/lib/pages/company_site/eti_page.rb
+++ b/lib/pages/company_site/eti_page.rb
@@ -84,6 +84,7 @@ module CompanySite
     span(:group_cell, css: '.js-group-preview-link')
     button(:submit, css: '.groups-popup__save-button')
     button(:close_support_contacts, css: '.js-support-contacts-close')
+    button(:navigate_to_groups, css: '[for=rubricator_type_groups]')
 
     title(:project_pulscen, xpath: "//title[contains(text(), 'Пульс')]")
     title(:project_blizko, xpath: "//a[@title='Главная страница Blizko']")
@@ -255,7 +256,8 @@ module CompanySite
       end
 
       def set_exists(value)
-        Page.link(:exists_link, xpath: "//li/a[text()='#{value}']")
+        Page.link(:exists_link, xpath: "//label[text()[contains(., '#{value}')]]")
+        Page.button(:save_exists, css: '.popup-exists__save-button')
 
         browser
           .action
@@ -264,6 +266,7 @@ module CompanySite
           .perform
 
         exists_link
+        save_exists
         wait_saving
       end
     end
@@ -352,6 +355,7 @@ module CompanySite
 
     def set_group(name)
       Page.button(:product_group, xpath: "//*[@id='popup-content']//*[contains(text(), '#{name}')]")
+      wait_until { group_cell? }
       group_cell_element.click
       product_group
       submit


### PR DESCRIPTION
https://jira.railsc.ru/browse/AT-571
Поправил падающие тесты в геме:
- выбор группы
![image](https://github.com/abak-press/apress-selenium_eti/assets/93905427/0bb0213a-72bb-4b25-a39a-01036f36c54c)
- создание товара копированием
![image](https://github.com/abak-press/apress-selenium_eti/assets/93905427/0d86f9c4-43ff-4b2d-b943-9e0fd4d24a84)
