### PR TITLE
fix(selenium): fix eti specs and minieti_spec; add deals popup

### DIFF
--- a/lib/apress/selenium_eti.rb
+++ b/lib/apress/selenium_eti.rb
@@ -13,7 +13,9 @@ require "#{gem_directory}/lib/pages/company_site/eti/table_status_bar"
 require "#{gem_directory}/lib/pages/company_site/eti/navigation_column"
 
 # Попапы
+require "#{gem_directory}/lib/pages/company_site/eti/popups/deals_popup"
 require "#{gem_directory}/lib/pages/company_site/eti/popups/description_popup"
+require "#{gem_directory}/lib/pages/company_site/eti/popups/exists_popup"
 require "#{gem_directory}/lib/pages/company_site/eti/popups/groups_binding_popup"
 require "#{gem_directory}/lib/pages/company_site/eti/popups/images_upload_popup"
 require "#{gem_directory}/lib/pages/company_site/eti/popups/price_popup"
@@ -21,7 +23,6 @@ require "#{gem_directory}/lib/pages/company_site/eti/popups/public_state_popup"
 require "#{gem_directory}/lib/pages/company_site/eti/popups/rubrics_binding_popup"
 require "#{gem_directory}/lib/pages/company_site/eti/popups/traits_popup"
 require "#{gem_directory}/lib/pages/company_site/eti/popups/wholesale_price_popup"
-require "#{gem_directory}/lib/pages/company_site/eti/popups/exists_popup"
 
 # Мини-ЕТИ.
 require "#{gem_directory}/lib/pages/company_site/mini_eti/mini_eti"

--- a/lib/apress/selenium_eti/spec/company_site/eti/product_creation_spec.rb
+++ b/lib/apress/selenium_eti/spec/company_site/eti/product_creation_spec.rb
@@ -26,16 +26,16 @@ describe 'ЕТИ' do
 
       it('введенное имя отображается') { expect(@cs_eti_table_products.name(@product)).to eq(@name) }
 
-      # Определяется через локатор какой проект, и в зависимости
-      # от этого ожидаемый результат. Если ни один из локаторов
-      # проектов не найден, то выводится ошибка 'locator not found'
+      # На БЛ, если товар без рубрики, то статус_публикации у него unpublished (опубликованный на ск).
+      # Если лимиты публикации на ск забиты, то статус_публикации у товара будет archived.
+      # На ПЦ, если товар без рубрики, то статус_публикации у него сразу archived.
+      # Здесь выполняется проверка, является ли статус_публикации archived,
+      # иначе проверка на unpublished для БЛ.
       it 'товар не опубликован на портале' do
-        if @cs_eti_table.project_pulscen?
+        if @cs_eti_table_products.public_state(@product) == :archived
           expect(@cs_eti_table_products.public_state(@product)).to eq(:archived)
-        elsif @cs_eti_table.project_blizko?
-          expect(@cs_eti_table_products.public_state(@product)).to eq(:unpublished)
         else
-          raise ArgumentError, 'locator not found'
+          expect(@cs_eti_table_products.public_state(@product)).to eq(:unpublished)
         end
       end
     end

--- a/lib/apress/selenium_eti/spec/company_site/eti/product_price_spec.rb
+++ b/lib/apress/selenium_eti/spec/company_site/eti/product_price_spec.rb
@@ -29,7 +29,10 @@ describe 'ЕТИ' do
         }
       end
 
-      it 'введеная цена отображается' do
+      # Определяется через локатор какой проект, и в зависимости
+      # от этого ожидаемый результат. Если ни один из локаторов
+      # проектов не найден, то выводится ошибка 'locator not found'
+      it 'введеная цена отображается, в рублях' do
         if @cs_eti_table.project_pulscen?
           expect(@cs_eti_table_products.price(@product)).to eq("#{price[:price]} руб.")
         elsif @cs_eti_table.project_blizko?
@@ -41,7 +44,7 @@ describe 'ЕТИ' do
     end
 
     context 'когда цена от и до', story: 'когда цена от и до' do
-      context 'когда только "от"' do
+      context 'когда только От' do
         let(:price) do
           {
             type: :range,
@@ -50,17 +53,11 @@ describe 'ЕТИ' do
         end
 
         it 'введеная цена отображается' do
-          if @cs_eti_table.project_pulscen?
-            expect(@cs_eti_table_products.price(@product)).to eq("от #{price[:price]} руб.")
-          elsif @cs_eti_table.project_blizko?
-            expect(@cs_eti_table_products.price(@product)).to eq("от #{price[:price]} ₽")
-          else
-            raise ArgumentError, 'locator not found'
-          end
+          expect(@cs_eti_table_products.price(@product)).to include("от #{price[:price]}")
         end
       end
 
-      context 'когда только "до"' do
+      context 'когда только До' do
         let(:price) do
           {
             type: :range,
@@ -69,17 +66,11 @@ describe 'ЕТИ' do
         end
 
         it 'введеная цена отображается' do
-          if @cs_eti_table.project_pulscen?
-            expect(@cs_eti_table_products.price(@product)).to eq("до #{price[:price_max]} руб.")
-          elsif @cs_eti_table.project_blizko?
-            expect(@cs_eti_table_products.price(@product)).to eq("до #{price[:price_max]} ₽")
-          else
-            raise ArgumentError, 'locator not found'
-          end
+          expect(@cs_eti_table_products.price(@product)).to include("до #{price[:price_max]}")
         end
       end
 
-      context 'когда заполняем "от" и "до"' do
+      context 'когда заполняем От и До' do
         let(:price) do
           {
             type: :range,
@@ -127,15 +118,8 @@ describe 'ЕТИ' do
       end
 
       it 'введеная цена отображается' do
-        if @cs_eti_table.project_pulscen?
-          expect(@cs_eti_table_products.wholesale_price(@product))
-            .to eq("#{wholesale_price[:price]} руб. /шт. от #{wholesale_price[:min_qty]} шт.")
-        elsif @cs_eti_table.project_blizko?
-          expect(@cs_eti_table_products.wholesale_price(@product))
-            .to eq("#{wholesale_price[:price]} ₽ /шт. от #{wholesale_price[:min_qty]} шт.")
-        else
-          raise ArgumentError, 'locator not found'
-        end
+        expect(@cs_eti_table_products.wholesale_price(@product))
+          .to include(wholesale_price[:price].to_s, wholesale_price[:min_qty].to_s)
       end
     end
 
@@ -148,7 +132,7 @@ describe 'ЕТИ' do
         }
       end
 
-      it 'введеная цена отображается' do
+      it 'введеная цена отображается, в рублях' do
         if @cs_eti_table.project_pulscen?
           expect(@cs_eti_table_products.wholesale_price(@product))
             .to eq("от #{wholesale_price[:price]} руб. /шт. от #{wholesale_price[:min_qty]} шт.")

--- a/lib/apress/selenium_eti/version.rb
+++ b/lib/apress/selenium_eti/version.rb
@@ -1,5 +1,5 @@
 module Apress
   module SeleniumEti
-    VERSION = '0.6.15'.freeze
+    VERSION = '0.6.16'.freeze
   end
 end

--- a/lib/pages/company_site/eti/header.rb
+++ b/lib/pages/company_site/eti/header.rb
@@ -5,9 +5,9 @@ module CompanySite
     class Header < Page
       include CompanySite::ETI
 
-      checkbox(:exact_search, css: '#exact_search')
+      checkbox(:exact_search, css: '#search-checkbox-exact')
       text_area(:search_string, xpath: "//*[@id='product-bindings-search']")
-      button(:search_button, css: '.js-search-submit')
+      button(:search_button, css: '.js-eti-search-submit')
       div(:search_type, css: '.selected-search-type')
       label(:full_search, css: 'label[data-name="По названию, кр. описанию, артикулу"]')
       label(:search_by_name, css: 'label[data-name="По названию"]')

--- a/lib/pages/company_site/eti/popups/deals_popup.rb
+++ b/lib/pages/company_site/eti/popups/deals_popup.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CompanySite
+  module ETI
+    class Table
+      class DealsPopup < self
+        checkbox(:deal_checkbox, css: '.js-input-deals')
+        checkbox(:deal_product_checkbox, xpath: "//*[text()[contains(., \'#{CONFIG['offer_with_product']}\')]]/input")
+        button(:save_deals, css: 'div.ui-dialog div > button:nth-child(1)')
+      end
+    end
+  end
+end

--- a/lib/pages/company_site/eti/popups/images_upload_popup.rb
+++ b/lib/pages/company_site/eti/popups/images_upload_popup.rb
@@ -7,7 +7,7 @@ module CompanySite
         div(:popup, css: '.js-popup-photo')
 
         button(:close, css: '.ui-dialog:not([style*="display: none"]) .ui-dialog-titlebar-close')
-        file_field(:upload_image_input, css: '.js-popup-photo .js-upload-input')
+        file_field(:upload_image_input, css: '.js-popup-photo .js-upload-image-input')
         text_area(:image_url, css: '.js-popup-photo .js-download-input')
         button(:image_url_submit, css: '.js-popup-photo .js-download-button')
         elements(:uploaded_images, css: '.js-popup-photo .js-img')

--- a/lib/pages/company_site/eti/table_products.rb
+++ b/lib/pages/company_site/eti/table_products.rb
@@ -4,28 +4,23 @@ module CompanySite
   module ETI
     class Table
       class Products < self
-        # EXISTS = {
-        #   available: 'В наличии',
-        #   not_available: 'Нет в наличии',
-        #   order: 'Под заказ',
-        #   awaiting: 'Ожидается поступление',
-        #   none: 'Не указано'
-        # }.freeze
-
         # Кнопка добавления нового товара
         button(:add_new_product, css: '.new-row-product')
+
+        # Плейсхолдер у названия нового пустого товара
+        span(:empty_product_name, xpath: "//*[text()[contains(., 'Указать название')]]")
 
         # Ячейки товара
         elements(:products, :row, css: '*[id^="product-item"]')
         elements(:names, :cell, css: '.js-eti-name')
         elements(:rubrics, :cell, css: '.js-eti-rubric')
         elements(:images, :cell, css: '*[id^="product-item"] *[class*="ibb"]')
-        elements(:images_counters, :div, css: '*[id^="product-item"] *[class="ip-count"]')
+        elements(:images_counters, :div, css: '*[id^="product-item"] *[class="saved-images-count"]')
         elements(:public_state_icon, :cell, css: '.js-eti-status')
         elements(:battery_level, :cell, css: '.js-battery-wrapper')
         elements(:battery_title, :cell, css: '.battery')
         elements(:rubric_link, :cell, css: '.js-rubric-preview-link')
-        elements(:exists_link, :cell, css: '.js-eti-exists [title="Указать наличие"]')
+        elements(:exists_link, :cell, css: '.js-eti-exists .dashed-span')
         elements(:announces, :cell, css: '.js-eti-announce')
         elements(:prices, :cell, css: '.js-eti-price [title="Изменить цену"]')
         elements(:wholesale_prices, :cell, css: '.js-eti-wholesaleprice [title="Указать оптовую цену"]')
@@ -39,6 +34,12 @@ module CompanySite
         # Кнопки в плашке, появляющейся при наведении на строку товара
         button(:delete_product_icon, css: '.js-delete-product')
         elements(:copy_product_icon, css: '.js-copy-product')
+
+        # Чекбокс у строки товара
+        checkbox(:product_checkbox, css: '.js-check-product')
+
+        # Массовое действие "Добавить к акции"
+        button(:add_products_to_deal, css: '.js-deals-config')
 
         # @return элемент строки товара и таблицы Selenium::WebDriver::Element
         #

--- a/lib/pages/company_site/mini_eti/pagination.rb
+++ b/lib/pages/company_site/mini_eti/pagination.rb
@@ -8,9 +8,8 @@ module CompanySite
       div(:current_page, css: '.js-eti-pagination-root .b-pagination_listItemCurrent')
       button(:previous_page_link, css: '.js-eti-pagination-root .b-pagination_headItemPrevious')
       button(:next_page_link, css: '.js-eti-pagination-root .b-pagination_headItemNext')
-      elements(:per_page_value, css: '.js-choose-amount-combobox a')
-      div(:current_per_page, css: '.ptrfap-choose-amount-wrapper .custom-combobox-input')
-      button(:per_page_button, css: '.ptrfap-choose-amount-wrapper .custom-combobox-toggle')
+      elements(:per_page_value, css: '.js-eti-filter-options-per_page')
+      button(:per_page_button, css: '.ptrfap-choose-amount-wrapper .js-eti-filter-per_page')
 
       def next_page
         wait_until_table_update { next_page_link }


### PR DESCRIPTION
https://jira.railsc.ru/browse/AT-596

Была проблема на БЛ: много падающих тестов приводили не к полному прогону тестов на БЛ (было ~1350 тестов, стало ~950 тестов). Сейчас прогоняется снова 1350 тестов.
Прогнон тестов на проектах:
ПЦ http://allure-mybranch-pc.knife.railsc.ru/
БЛ http://allure-mybranch-bl.knife.railsc.ru/

А также
Для обоих проектов ПЦ и БЛ:
- Сократил прогон спеков ЕТИ примерно на 1 минуту (плюс-минус)
- Актуализировал локаторы после редизайна ЕТИ
- Добавил новый попап, в котором проставляется акция у товара